### PR TITLE
Add Android namespace for AGP 8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'store.checker.store_checker'
+    }
+
     compileSdkVersion 28
 
     defaultConfig {


### PR DESCRIPTION
> Adds a `namespace` attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0 [...]

Source: [https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b](https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b)